### PR TITLE
[Fix] daetaDescription 관련 버그 수정

### DIFF
--- a/app/src/main/java/com/ssuandroid/my_parttime/DescriptionReg_DialogFragment.java
+++ b/app/src/main/java/com/ssuandroid/my_parttime/DescriptionReg_DialogFragment.java
@@ -74,6 +74,7 @@ public class DescriptionReg_DialogFragment extends DialogFragment implements Vie
         closeButton.setOnClickListener(this);
         Button inputButton = (Button) v.findViewById(R.id.description_regBtn);
         inputButton.setOnClickListener(this);
+        TextView albasaeng = (TextView) v.findViewById(R.id.alba_text);
 
         setCancelable(false); //화면 터치 시 꺼짐을 막음
 
@@ -91,7 +92,7 @@ public class DescriptionReg_DialogFragment extends DialogFragment implements Vie
                                 SimpleDateFormat sdf = new SimpleDateFormat("dd");
                                 sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
                                 String day = String.valueOf(Integer.parseInt(sdf.format(timestampToDate)));
-                                if (day.equals(itemDay)) {
+                                if (day.equals(itemDay) && !((boolean) document.get("covered"))) {
                                     String writerId = (String) document.get("writerId");
                                     participationCode = (String) document.get("participationCode");
                                     date = (Timestamp) document.get("date");
@@ -106,13 +107,14 @@ public class DescriptionReg_DialogFragment extends DialogFragment implements Vie
                                                     if(task.isSuccessful()) {
                                                         for (QueryDocumentSnapshot document : task.getResult()) {
                                                             name.setText((String) document.get("name"));
+                                                            albasaeng.setText("알바생");
+                                                            inputButton.setEnabled(true);
                                                         }
                                                     }  else {
                                                         Log.d("Surin", "Error getting documents: ", task.getException());
                                                     }
                                                 }
                                             });
-
                                     description.setText((String) document.get("description"));
                                     daeta = new Daeta(participationCode, branchName, wage, timestampToDate, (String) document.get("time"), (String) document.get("description"), (String) document.get("writerId"), null, (boolean) document.get("externalTF"));
                                 }

--- a/app/src/main/res/layout/dialogfragment_descriptionreg.xml
+++ b/app/src/main/res/layout/dialogfragment_descriptionreg.xml
@@ -29,16 +29,17 @@
             android:paddingTop="8dp"
             android:fontFamily="@font/bold"
             android:textColor="@color/black"
-            android:text="홍길동"
+            android:text=""
             android:textSize="25sp"></TextView>
 
         <TextView
+            android:id="@+id/alba_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="10sp"
             android:paddingTop="8dp"
             android:textColor="@color/black"
-            android:text="알바생"
+            android:text="구인 중인 공고가 없어요!"
             android:textSize="15sp"></TextView>
 
 
@@ -56,7 +57,7 @@
             android:layout_width="200dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="10월 21일 시험 일정이 있어 19-21 대타 구합니다"
+            android:text=""
             android:textSize="15dp">
         </TextView>
 
@@ -83,7 +84,8 @@
             android:layout_width="80sp"
             android:layout_height="40sp"
             android:background="@drawable/daetaapplication_button_custom_confirm"
-            android:text="신청 "></Button>
+            android:text="신청 "
+            android:enabled="false" />
 
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
![image](https://github.com/RinRinPARK/MyPartTimeJob-Android/assets/87180069/ce7cb089-e9f0-45ca-aa53-b431c622b066)
- 대타 구인이 완료된 공고가 대타 캘린더 description에 뜨는 버그 수정
- 캘린더에서 구인 없는 날(구하기 등록이 아예 없거나, 구인 완료된 날) 누르면 '구인 중인 공고가 없어요!' 텍스트 출력 및 신청버튼 비활성
-> 근데 flag로 사용할 변수들 이리 저리 해봤는데 파이어베이스가 비동기적으로 데이터를 불러오는 듯하여 안됨.. 그래서 그냥 daeta description의 기본 디폴트 값을 '구인 중인 공고가 없어요!' 텍스트 및 신청버튼 비활성으로 바꾸고, 공고 있을 때마다 텍스트는 '알바생'으로 바꾸고 신청버튼 활성화하는 것으로 로직 수정